### PR TITLE
Details view for producers

### DIFF
--- a/AppalachianHarvest/Controllers/ProducersController.cs
+++ b/AppalachianHarvest/Controllers/ProducersController.cs
@@ -45,10 +45,17 @@ namespace AppalachianHarvest.Controllers
             }
 
             var producer = await _context.Producers
+                .Include(p=>p.Products)
+                .ThenInclude(pr=>pr.ProductType)
                 .FirstOrDefaultAsync(m => m.ProducerId == id);
             if (producer == null)
             {
                 return NotFound();
+            }
+            foreach (Product product in producer.Products)
+            {
+                TimeSpan expirationTime = TimeSpan.FromDays(Convert.ToDouble(product.ProductType.TimeToExpire));
+                product.ExpirationDate = product.Added.Add(expirationTime);
             }
 
             return View(producer);

--- a/AppalachianHarvest/Data/ApplicationDbContext.cs
+++ b/AppalachianHarvest/Data/ApplicationDbContext.cs
@@ -48,6 +48,7 @@ namespace AppalachianHarvest.Data
             user.PasswordHash = passwordHash.HashPassword(user, "Admin8*");
             modelBuilder.Entity<ApplicationUser>().HasData(user);
 
+
             modelBuilder.Entity<Order>()
                 .Property(b => b.OrderDate)
                 .HasDefaultValueSql("GETDATE()");
@@ -251,7 +252,8 @@ namespace AppalachianHarvest.Data
                      IsActive = true,
                      Added = DateTime.Now
 
-                 });
+                 }                
+                 );
 
             modelBuilder.Entity<Order>().HasData(
                new Order()

--- a/AppalachianHarvest/Views/Producers/Details.cshtml
+++ b/AppalachianHarvest/Views/Producers/Details.cshtml
@@ -70,70 +70,88 @@
             @Html.DisplayFor(model => model.IsActive)
         </dd>
     </dl>
+
     <h4>Products:</h4>
-    <table class="table" style="width:50%">
+   @{
+       List<Product> unexpiredProducts = new List<Product>(); 
+       }
 
-        <thead>
-            <tr>
-                
-                <th>
-                    Name
-                </th>
-                <th>
-                    Qty.
-                </th>
-                <th>
-                    Price
-                </th>
-                <th>
-                    Date Added
-                </th>
-                <th>
-                    Expiration
-                </th>
-            </tr>
-        </thead>
+    @foreach (Product product in Model.Products){
+        if (product.ExpirationDate >= DateTime.Now) {
 
-        <tbody>
-            @foreach (Product product in Model.Products)
-            {
-                if (product.ExpirationDate >= DateTime.Now)
-                {
+            unexpiredProducts.Add(product);
+        }
+    }
+
+        @if (unexpiredProducts.Count() > 0)
+        {
+            <table class="table" style="width:50%">
+
+                <thead>
                     <tr>
-                        
-                        <td>
-                            @if (product.IsOrganic == true)
-                            {
-                                var imgSrc2 = Url.Content("https://localhost:5001/Images/organic-icon.png");
 
-                                <img class="productImgThumb" style="width:15px" src="@imgSrc2" />
-                            }
-                            @Html.ActionLink(product.Name, "Details", "Products", new { Id = product.ProductId }, null)
-                        </td>
-
-
-                        <td>
-                            @Html.DisplayFor(modelItem => product.Quantity)
-                        </td>
-                        <td>
-                            @Html.DisplayFor(modelItem => product.Price)
-                        </td>
-
-                        <td>
-                            @Html.DisplayFor(modelItem => product.Added)
-                        </td>
-                        <td>
-                            @product.ExpirationDate.ToShortDateString()
-                        </td>
-
-
+                        <th>
+                            Name
+                        </th>
+                        <th>
+                            Qty.
+                        </th>
+                        <th>
+                            Price
+                        </th>
+                        <th>
+                            Date Added
+                        </th>
+                        <th>
+                            Expiration
+                        </th>
                     </tr>
+                </thead>
 
-                }
-            }
-        </tbody>
-        </table>
+                <tbody>
+                    @foreach (Product product in unexpiredProducts)
+                    {                        
+                            <tr>
 
+                                <td>
+                                    @Html.ActionLink(product.Name, "Details", "Products", new { Id = product.ProductId }, null)
+
+                                    @if (product.IsOrganic == true)
+                                    {
+                                        var imgSrc2 = Url.Content("https://localhost:5001/Images/organic-icon.png");
+
+                                        <img class="productImgThumb" style="width:15px" src="@imgSrc2" />
+                                    }
+
+                                </td>
+
+
+                                <td>
+                                    @Html.DisplayFor(modelItem => product.Quantity)
+                                </td>
+                                <td>
+                                    @Html.DisplayFor(modelItem => product.Price)
+                                </td>
+
+                                <td>
+                                    @Html.DisplayFor(modelItem => product.Added)
+                                </td>
+                                <td>
+                                    @product.ExpirationDate.ToShortDateString()
+                                </td>
+
+
+                            </tr>
+
+                        
+                    }
+                </tbody>
+            </table>
+        }
+        else
+        {
+            <p>No products currently in market</p>
+        }
 </div>
 <div>
     <a asp-action="Edit" asp-route-id="@Model.ProducerId">Edit</a> |

--- a/AppalachianHarvest/Views/Producers/Details.cshtml
+++ b/AppalachianHarvest/Views/Producers/Details.cshtml
@@ -75,8 +75,7 @@
 
         <thead>
             <tr>
-                <th>
-                </th>
+                
                 <th>
                     Name
                 </th>
@@ -101,12 +100,7 @@
                 if (product.ExpirationDate >= DateTime.Now)
                 {
                     <tr>
-                        <td>
-
-
-                            @*<img class="productImgThumb" style="width:40px" src="@imgSrc2" />*@
-
-                        </td>
+                        
                         <td>
                             @if (product.IsOrganic == true)
                             {

--- a/AppalachianHarvest/Views/Producers/Details.cshtml
+++ b/AppalachianHarvest/Views/Producers/Details.cshtml
@@ -2,6 +2,8 @@
 
 @{
     ViewData["Title"] = "Details";
+    var imgSrc = Url.Content("https://localhost:5001/Images/farmPlaceholder.jpg");
+
 }
 
 <h1>Details</h1>
@@ -10,73 +12,134 @@
     <h4>Producer</h4>
     <hr />
     <dl class="row">
-        <dt class = "col-sm-2">
-            @Html.DisplayNameFor(model => model.FirstName)
+
+        <dt class="col-sm-2">
+
+
+            @if (Model.ProducerImage != null)
+            {
+
+                var base64 = Convert.ToBase64String(Model.ProducerImage);
+                imgSrc = String.Format("data:image/gif;base64,{0}", base64);
+
+            }
+            <img class="productImgThumb" style="width:300px" src="@imgSrc" />
+
         </dt>
-        <dd class = "col-sm-10">
-            @Html.DisplayFor(model => model.FirstName)
+        <dd class="col-sm-10">
+
         </dd>
-        <dt class = "col-sm-2">
-            @Html.DisplayNameFor(model => model.LastName)
+        <dt class="col-sm-2">
+            Producer Name
         </dt>
-        <dd class = "col-sm-10">
-            @Html.DisplayFor(model => model.LastName)
+        <dd class="col-sm-10">
+            @Html.DisplayFor(model => model.FirstName)  @Html.DisplayFor(model => model.LastName)
         </dd>
-        <dt class = "col-sm-2">
+
+        <dt class="col-sm-2">
             @Html.DisplayNameFor(model => model.BusinessName)
         </dt>
-        <dd class = "col-sm-10">
+        <dd class="col-sm-10">
             @Html.DisplayFor(model => model.BusinessName)
         </dd>
-        <dt class = "col-sm-2">
+        <dt class="col-sm-2">
             @Html.DisplayNameFor(model => model.Phone)
         </dt>
-        <dd class = "col-sm-10">
+        <dd class="col-sm-10">
             @Html.DisplayFor(model => model.Phone)
         </dd>
-        <dt class = "col-sm-2">
+        <dt class="col-sm-2">
             @Html.DisplayNameFor(model => model.Email)
         </dt>
-        <dd class = "col-sm-10">
+        <dd class="col-sm-10">
             @Html.DisplayFor(model => model.Email)
         </dd>
-        <dt class = "col-sm-2">
+        <dt class="col-sm-2">
             @Html.DisplayNameFor(model => model.Address)
         </dt>
-        <dd class = "col-sm-10">
-            @Html.DisplayFor(model => model.Address)
+        <dd class="col-sm-10">
+            @Html.DisplayFor(model => model.Address) <br />
+
+            @Html.DisplayFor(model => model.City),  @Html.DisplayFor(model => model.State)   @Html.DisplayFor(model => model.ZipCode)
         </dd>
-        <dt class = "col-sm-2">
-            @Html.DisplayNameFor(model => model.City)
-        </dt>
-        <dd class = "col-sm-10">
-            @Html.DisplayFor(model => model.City)
-        </dd>
-        <dt class = "col-sm-2">
-            @Html.DisplayNameFor(model => model.State)
-        </dt>
-        <dd class = "col-sm-10">
-            @Html.DisplayFor(model => model.State)
-        </dd>
-        <dt class = "col-sm-2">
-            @Html.DisplayNameFor(model => model.ZipCode)
-        </dt>
-        <dd class = "col-sm-10">
-            @Html.DisplayFor(model => model.ZipCode)
-        </dd>
-        <dt class = "col-sm-2">
-            @Html.DisplayNameFor(model => model.ProducerImage)
-        </dt>
-        <dd class = "col-sm-10">
-            @*@Html.DisplayFor(model => model.ProducerImage*@
-        </dd>
-        <dt class = "col-sm-2">
+
+        <dt class="col-sm-2">
             @Html.DisplayNameFor(model => model.IsActive)
         </dt>
-        <dd class = "col-sm-10">
+        <dd class="col-sm-10">
             @Html.DisplayFor(model => model.IsActive)
         </dd>
     </dl>
+    <h4>Products:</h4>
+    <table class="table" style="width:50%">
+
+        <thead>
+            <tr>
+                <th>
+                </th>
+                <th>
+                    Name
+                </th>
+                <th>
+                    Qty.
+                </th>
+                <th>
+                    Price
+                </th>
+                <th>
+                    Date Added
+                </th>
+                <th>
+                    Expiration
+                </th>
+            </tr>
+        </thead>
+
+        <tbody>
+            @foreach (Product product in Model.Products)
+            {
+                if (product.ExpirationDate >= DateTime.Now)
+                {
+                    <tr>
+                        <td>
+
+
+                            @*<img class="productImgThumb" style="width:40px" src="@imgSrc2" />*@
+
+                        </td>
+                        <td>
+                            @if (product.IsOrganic == true)
+                            {
+                                var imgSrc2 = Url.Content("https://localhost:5001/Images/organic-icon.png");
+
+                                <img class="productImgThumb" style="width:15px" src="@imgSrc2" />
+                            }
+                            @Html.ActionLink(product.Name, "Details", "Products", new { Id = product.ProductId }, null)
+                        </td>
+
+
+                        <td>
+                            @Html.DisplayFor(modelItem => product.Quantity)
+                        </td>
+                        <td>
+                            @Html.DisplayFor(modelItem => product.Price)
+                        </td>
+
+                        <td>
+                            @Html.DisplayFor(modelItem => product.Added)
+                        </td>
+                        <td>
+                            @product.ExpirationDate.ToShortDateString()
+                        </td>
+
+
+                    </tr>
+
+                }
+            }
+        </tbody>
+        </table>
+
 </div>
 <div>
     <a asp-action="Edit" asp-route-id="@Model.ProducerId">Edit</a> |

--- a/AppalachianHarvest/Views/Products/Details.cshtml
+++ b/AppalachianHarvest/Views/Products/Details.cshtml
@@ -47,7 +47,7 @@
             @Html.DisplayNameFor(model => model.Producer)
         </dt>
         <dd class="col-sm-10">
-            @Html.DisplayFor(model => model.Producer.BusinessName)
+            @Html.ActionLink(Model.Producer.BusinessName, "Details", "Producers", new { Id = Model.Producer.ProducerId }, null)
         </dd>
         <dt class="col-sm-2">
             @Html.DisplayNameFor(model => model.Added)

--- a/AppalachianHarvest/Views/Products/Index.cshtml
+++ b/AppalachianHarvest/Views/Products/Index.cshtml
@@ -20,6 +20,7 @@
                 @Html.DisplayNameFor(model => model.Name)
             </th>
             <th>
+               
                 @Html.DisplayNameFor(model => model.Producer)
             </th>
 
@@ -63,7 +64,7 @@
                 </td>
 
                 <td>
-                    @Html.DisplayFor(modelItem => item.Producer.BusinessName)
+                    @Html.ActionLink(item.Producer.BusinessName, "Details", "Producers", new { Id = item.ProducerId }, null)
                 </td>
 
                 <td>
@@ -78,7 +79,7 @@
                     {
                         var imgSrc = Url.Content("https://localhost:5001/Images/organic-icon.png");
 
-                        <img class="productImgThumb" style="width:40px" src="@imgSrc" />
+                        <img class="productImgThumb" style="width:30px" src="@imgSrc" />
                     }
                 </td>
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,9 @@ Employees can delete products by clicking on the 'details' view of any product a
 ## Producers
 Employees can add producers to the database by navigating to the 'Producers' tab in the nav bar and clicking on the affordance  to add a new producer.  Enter all the information for the producer and click 'Create'.  Note:  Adding an image is option but all other fields are required.  Zipcode, email and phone have specific required formats.  On the index page, producers are displayed as cards.
 
+### Details
+Clicking on the details affordance for any producer will allow the user to see the producers detailed contact information as well as a list of all the products they currently have in the market.
+
 ### Editing Producers
 Employees can edit producers by clicking on the 'details' view of any producer, and clicking on the link to edit.  They will be presented with a form that is pre-populated with information about the producer.  They can change any of the details on that form and then click 'submit' to record the changes.
 


### PR DESCRIPTION
# Description
I updated the details view to show an image of the producer and all of their products currently in market


## Related Ticket(s)
https://github.com/sydneywait/AppalachianHarvest/issues/10


## Steps to Test
Add and commit before checking out to sw-producers-details
Navigate to the producers tab and click on the 'details' link in any producers card.  You should see an image of the producer or a placeholder.  You should also see the detailed contact information as well as a list of any products they have in the market.  If they do not have any unexpired products, you will need to add a product so you can see it.
If you click on the name of the product it should take you to the details view for that product.  Clicking on the name of the producer will take you back to the producer detail page.

# Checklist:
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have thoroughly tested functionality to ensure there are no new errors
- [x] I have double-checked all the razor views and looked at physical code changes
- [x] I have made corresponding changes to the documentation

